### PR TITLE
Pk bugfix

### DIFF
--- a/examples/models.py
+++ b/examples/models.py
@@ -301,6 +301,7 @@ class Parent(odm.StdModel):
 class Child(odm.StdModel):
     name = odm.SymbolField()
     parent = odm.ForeignKey(Parent)
+    uncles = odm.ManyToManyField(Parent, related_name='nephews')
 
 
 ####################################################

--- a/stdnet/odm/query.py
+++ b/stdnet/odm/query.py
@@ -69,7 +69,7 @@ class Q(object):
                      'ordering': ordering,
                      'fields': fields,
                      'get_field': get_field}
-        self.name = name if name is not None else self.name
+        self.name = name if name is not None else meta.pk.name
         self.keyword = keyword if keyword is not None else self.keyword
 
     @property

--- a/stdnet/odm/related.py
+++ b/stdnet/odm/related.py
@@ -257,7 +257,9 @@ used to hold the :ref:`many-to-many relationship <many-to-many>`.'''
     def query(self, session=None):
         # Return a query for the related model
         ids = self.throughquery(session).get_field(self.name_formodel)
-        return self.session(session).query(self.formodel).filter(id=ids)
+        pkey = self.formodel.pk().name
+        fargs = {pkey: ids}
+        return self.session(session).query(self.formodel).filter(**fargs)
 
 
 def makeMany2ManyRelatedManager(formodel, name_relmodel, name_formodel):

--- a/tests/all/fields/pk.py
+++ b/tests/all/fields/pk.py
@@ -7,13 +7,13 @@ from examples.models import Parent, Child
 
 class TestForeignKey(test.TestCase):
     models = (Parent, Child)
-    
+
     def test_custom_pk(self):
         models = self.mapper
         parent = yield models.parent.new(name='test')
         self.assertEqual(parent.pkvalue(), 'test')
         self.assertEqual(parent.pk().name, 'name')
-        
+
     def test_add_parent_and_child(self):
         models = self.mapper
         with models.session().begin() as t:
@@ -30,7 +30,10 @@ class TestQuery(test.TestCase):
     models = (Parent, Child)
 
     def test_non_id_pk(self):
-        ''' Models with non-'id' primary keys should be queryable '''
+        '''
+        Models with non-'id' primary keys should be queryable (regression test)
+
+        '''
         models = self.mapper
         with models.session().begin() as t:
             parent = models.parent(name='test2')
@@ -41,4 +44,28 @@ class TestQuery(test.TestCase):
         with models.session().begin() as t:
             parents = t.query(Parent).all()
             self.assertEqual(len(parents), 1)
+        yield t.on_result
+
+
+class TestManyToMany(test.TestCase):
+    models = (Parent, Child)
+
+    def test_non_id_pk(self):
+        '''
+        Models with non-'id' primary keys should be queryable from a ManyToMany
+        relation (regression test)
+
+        '''
+        models = self.mapper
+        with models.session().begin() as t:
+            parent = models.parent(name='test2')
+            uncle = models.parent(name='test3')
+            child = models.child(parent=parent, name='foo')
+            t.add(parent)
+            t.add(uncle)
+            t.add(child)
+        yield t.on_result
+        with models.session().begin() as t:
+            child.uncles.add(uncle)
+            self.assertEqual(len(child.uncles.all()), 1)
         yield t.on_result

--- a/tests/all/fields/pk.py
+++ b/tests/all/fields/pk.py
@@ -24,3 +24,21 @@ class TestForeignKey(test.TestCase):
             t.add(parent)
             t.add(child)
         yield t.on_result
+
+
+class TestQuery(test.TestCase):
+    models = (Parent, Child)
+
+    def test_non_id_pk(self):
+        ''' Models with non-'id' primary keys should be queryable '''
+        models = self.mapper
+        with models.session().begin() as t:
+            parent = models.parent(name='test2')
+            child = models.child(parent=parent, name='foo')
+            t.add(parent)
+            t.add(child)
+        yield t.on_result
+        with models.session().begin() as t:
+            parents = t.query(Parent).all()
+            self.assertEqual(len(parents), 1)
+        yield t.on_result


### PR DESCRIPTION
Found a couple of bugs when using models that have primary keys that are not named 'id'. The first was with queries, and the second was with ManyToMany relationships. Regression tests included.

I think there is another, similar bug [here](https://github.com/lsbardel/python-stdnet/blob/master/stdnet/odm/related.py#L35), but I haven't tested it yet.
