### PR TITLE
Interface mismatch with Redis backend

### DIFF
--- a/stdnet/backends/__init__.py
+++ b/stdnet/backends/__init__.py
@@ -319,7 +319,7 @@ this function for customizing their handling of connection parameters. It
 must return a instance of the backend handler.'''
         raise NotImplementedError()
 
-    def execute_session(self, session, callback):
+    def execute_session(self, session_data):
         '''Execute a :class:`stdnet.odm.Session` in the backend server.'''
         raise NotImplementedError()
 

--- a/tests/all/backends/interface.py
+++ b/tests/all/backends/interface.py
@@ -22,7 +22,7 @@ class TestBackend(test.TestCase):
         b = self.get_backend()
         self.assertEqual(str(b), 'dummy://127.0.0.1:9090')
         self.assertFalse(b.clean(None))
-        self.assertRaises(NotImplementedError, b.execute_session, None, None)
+        self.assertRaises(NotImplementedError, b.execute_session, None)
         self.assertRaises(NotImplementedError, b.model_keys, None)
         self.assertRaises(NotImplementedError, b.flush)
 


### PR DESCRIPTION
The only implementation of backend for Redis doesn't has second parameter, callback, but interface has.
Usage also drops the callback. So I assume the implementation is correct.
