### PR TITLE
docs: Fix a few typos

### DIFF
--- a/docs/source/examples/related.rst
+++ b/docs/source/examples/related.rst
@@ -6,7 +6,7 @@
 Related Models
 ============================
 
-There are two :class:`Fields` which represents relationaships between
+There are two :class:`Fields` which represents relationships between
 :class:`StdModel`. 
 
 

--- a/docs/source/examples/serialise.rst
+++ b/docs/source/examples/serialise.rst
@@ -15,7 +15,7 @@ There are two serializers included in the standard distribution: **json** and **
 Exporting Data
 ====================
 
-To export data is quite strightforward, you create a :class:`Query` and
+To export data is quite straightforward, you create a :class:`Query` and
 pass it to a :meth:`Serializer.dump` method. Using the
 :ref:`models router <tutorial-models-router>` in the first tutorial::
 

--- a/examples/permissions.py
+++ b/examples/permissions.py
@@ -175,9 +175,9 @@ class GroupManager(odm.Manager):
             return query
         roles = group.roles.query()
         roles = group.roles.query()  # query on all roles for group
-        # The throgh model for Role/Permission relationship
-        throgh_model = models.role.permissions.model
-        models[throgh_model].filter(role=roles,
+        # The through model for Role/Permission relationship
+        through_model = models.role.permissions.model
+        models[through_model].filter(role=roles,
                                     permission__model_type=query.model,
                                     permission__operations=operations)
 

--- a/stdnet/backends/redisb/__init__.py
+++ b/stdnet/backends/redisb/__init__.py
@@ -16,7 +16,7 @@ MIN_FLOAT = -1.e99
 ############################################################################
 #    prefixes for data
 OBJ = 'obj'     # the hash table for a instance
-TMP = 'tmp'     # temorary key
+TMP = 'tmp'     # temporary key
 ODM_SCRIPTS = ('odmrun', 'move2set', 'zdiffstore')
 ############################################################################
 

--- a/stdnet/odm/fields.py
+++ b/stdnet/odm/fields.py
@@ -692,7 +692,7 @@ the database field for the ``File`` model will have a ``folder_id`` field.
 
 class JSONField(CharField):
     '''A JSON field which implements automatic conversion to
-and from an object and a JSON string. It is the responsability of the
+and from an object and a JSON string. It is the responsibility of the
 user making sure the object is JSON serializable.
 
 There are few extra parameters which can be used to customize the

--- a/stdnet/odm/mapper.py
+++ b/stdnet/odm/mapper.py
@@ -252,7 +252,7 @@ For example::
             manager.create_all()
 
     def add(self, instance):
-        '''Add an ``instance`` to its backend database. This is a shurtcut
+        '''Add an ``instance`` to its backend database. This is a shortcut
 method for::
 
     self.session().add(instance)

--- a/stdnet/odm/search.py
+++ b/stdnet/odm/search.py
@@ -124,7 +124,7 @@ Can and should be reimplemented by subclasses.'''
         '''Add a *middleware* function to the list of :attr:`word_middleware`,
 for preprocessing words to be indexed.
 
-:param middleware: a callable receving an iterable over words.
+:param middleware: a callable receiving an iterable over words.
 :param for_search: flag indicating if the *middleware* can be used for the
     text to search. Default: ``True``.
 '''

--- a/stdnet/odm/session.py
+++ b/stdnet/odm/session.py
@@ -913,7 +913,7 @@ so by setting the ``manager_class`` attribute in the :class:`StdModel`::
 
     def __call__(self, *args, **kwargs):
         # The callable method is equivalent of doing self.model() it is just
-        # a shurtcut for a better API
+        # a shortcut for a better API
         return self.model(*args, **kwargs)
 
     def session(self, session=None):

--- a/stdnet/utils/test.py
+++ b/stdnet/utils/test.py
@@ -109,7 +109,7 @@ several class methods for testing in a parallel test suite.
     * ``multipledb = False`` The test case does not require a backend and
       only one :class:`TestCase` class is added to the test-suite regardless
       of which backend has been tested.
-    * ``multipledb = True``, the default falue. Create as many
+    * ``multipledb = True``, the default false. Create as many
       :class:`TestCase` classes as the number of backend tested, each backend
       will run the tests.
     * ``multipledb = string, list, tuple``, Only those backend will run tests.


### PR DESCRIPTION
There are small typos in:
- docs/source/examples/related.rst
- docs/source/examples/serialise.rst
- examples/permissions.py
- stdnet/backends/redisb/__init__.py
- stdnet/odm/fields.py
- stdnet/odm/mapper.py
- stdnet/odm/search.py
- stdnet/odm/session.py
- stdnet/utils/test.py

Fixes:
- Should read `shortcut` rather than `shurtcut`.
- Should read `false` rather than `falue`.
- Should read `through` rather than `throgh`.
- Should read `temporary` rather than `temorary`.
- Should read `straightforward` rather than `strightforward`.
- Should read `responsibility` rather than `responsability`.
- Should read `relationships` rather than `relationaships`.
- Should read `receiving` rather than `receving`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md